### PR TITLE
start using log/slog package for structured logging

### DIFF
--- a/bus/metadata.go
+++ b/bus/metadata.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	"log/slog"
 
 	"net/http"
 	"net/url"
@@ -71,7 +71,7 @@ func (b bus) PurgeQueue(queue string) error {
 		return err
 	}
 
-	log.Printf("body: %v", string(body))
+	slog.Debug(fmt.Sprintf("body: %v", string(body)))
 
 	return nil
 }

--- a/bus/send.go
+++ b/bus/send.go
@@ -3,7 +3,8 @@ package bus
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"fmt"
+	"log/slog"
 
 	"github.com/streadway/amqp"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -17,7 +18,7 @@ func (b bus) Send(ctx context.Context, msg Message, headers map[string]interface
 	span.SetTag("exchange", msg.Exchange())
 	span.SetTag("route", msg.Route())
 
-	log.Printf("sending message to exchange/route: %s/%s", msg.Exchange(), msg.Route())
+	slog.DebugContext(ctx, fmt.Sprintf("sending message to exchange/route: %s/%s", msg.Exchange(), msg.Route()))
 
 	ch, err := b.conn.Channel()
 	if err != nil {
@@ -51,7 +52,7 @@ func (b bus) SendRaw(ctx context.Context, exchange string, route string, body []
 	span.SetTag("exchange", exchange)
 	span.SetTag("route", route)
 
-	log.Printf("sending message to exchange/route: %s/%s", exchange, route)
+	slog.DebugContext(ctx, fmt.Sprintf("sending message to exchange/route: %s/%s", exchange, route))
 
 	ch, err := b.conn.Channel()
 	if err != nil {

--- a/bus/subscription.go
+++ b/bus/subscription.go
@@ -2,7 +2,7 @@ package bus
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/streadway/amqp"
 )
@@ -31,25 +31,25 @@ func (b bus) Declare(sub Subscription) error {
 
 	durable := b.config.Durable
 
-	log.Printf("declaring queue: %s", sub.Queue)
+	slog.Info(fmt.Sprintf("declaring queue: %s", sub.Queue))
 	_, err = ch.QueueDeclare(sub.Queue, durable, false, false, false, nil)
 	if err != nil {
 		return err
 	}
 
-	log.Printf("declaring queue: %s", sub.DLQName())
+	slog.Info(fmt.Sprintf("declaring queue: %s", sub.DLQName()))
 	_, err = ch.QueueDeclare(sub.DLQName(), durable, false, false, false, nil)
 	if err != nil {
 		return err
 	}
 
-	log.Printf("declaring exchange: %s (type: %s)", sub.Exchange, b.config.ExchangeType)
+	slog.Info(fmt.Sprintf("declaring exchange: %s (type: %s)", sub.Exchange, b.config.ExchangeType))
 	err = ch.ExchangeDeclare(sub.Exchange, b.config.ExchangeType, durable, false, false, false, nil)
 	if err != nil {
 		return err
 	}
 
-	log.Printf("binding queue %s to exchange/route: %s/%s", sub.Queue, sub.Exchange, sub.Route)
+	slog.Info(fmt.Sprintf("binding queue %s to exchange/route: %s/%s", sub.Queue, sub.Exchange, sub.Route))
 	err = ch.QueueBind(sub.Queue, sub.Route, sub.Exchange, false, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
Now that we're using `log/slog` in our services for shipping structured logs to Datadog we should be using that in this package, too.